### PR TITLE
refactor(core): allow UnitEnum in navigationGroup

### DIFF
--- a/src/Concerns/Plugin/HasNavigation.php
+++ b/src/Concerns/Plugin/HasNavigation.php
@@ -197,7 +197,7 @@ trait HasNavigation
         return $this->getPropertyWithDefaults('navigationBadgeColor', $resourceClass);
     }
 
-    public function getNavigationGroup(?string $resourceClass = null): ?string
+    public function getNavigationGroup(?string $resourceClass = null): string | UnitEnum | null
     {
         return $this->getPropertyWithDefaults('navigationGroup', $resourceClass);
     }

--- a/src/Concerns/Resource/HasNavigation.php
+++ b/src/Concerns/Resource/HasNavigation.php
@@ -7,6 +7,7 @@ namespace BezhanSalleh\PluginEssentials\Concerns\Resource;
 use BackedEnum;
 use Filament\Pages\Enums\SubNavigationPosition;
 use Illuminate\Contracts\Support\Htmlable;
+use UnitEnum;
 
 trait HasNavigation
 {
@@ -51,7 +52,7 @@ trait HasNavigation
             : $pluginResult;
     }
 
-    public static function getNavigationGroup(): ?string
+    public static function getNavigationGroup(): string | UnitEnum | null
     {
         $pluginResult = static::delegateToPlugin(
             'HasNavigation',


### PR DESCRIPTION
This Pr fixes a bug where passing a UnitEnum to navigationGroup() caused the item to not be grouped.
