### PR TITLE
Fix broken readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
     <a href="https://github.com/bezhansalleh/filament-plugin-essentials/actions?query=workflow%3Arun-tests+branch%3Amain" class="filament-hidden">
         <img alt="Tests Passing" src="https://img.shields.io/github/actions/workflow/status/bezhansalleh/filament-plugin-essentials/run-tests.yml?style=for-the-badge&logo=github&label=tests" class="filament-hidden">
     </a>
-    <a href="https://github.com/bezhansalleh/filament-plugin-essentials/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain class="filament-hidden">
+    <a href="https://github.com/bezhanSalleh/filament-plugin-essentials/actions/workflows/fix-php-code-style-issues.yml?query=branch%3Amain" class="filament-hidden">
         <img alt="Code Style Passing" src="https://img.shields.io/github/actions/workflow/status/bezhansalleh/filament-plugin-essentials/fix-php-code-style-issues.yml?style=for-the-badge&logo=github&label=code%20style">
     </a>
 


### PR DESCRIPTION
This fixes a broken link inside the code style badge, which resulted in a broken redirect target and while most parsers ignore this, some like the one in phpStorm just stopped parsing the file after the link.

<img width="3732" height="1882" alt="CleanShot 2026-05-24 at 01 51 31" src="https://github.com/user-attachments/assets/c1491c01-c8a7-41ae-b9e1-d7f0667c258a" />
